### PR TITLE
Correção do carrinho

### DIFF
--- a/doc/api/rest_api.yaml
+++ b/doc/api/rest_api.yaml
@@ -785,7 +785,7 @@ paths:
       security:
         - bearerAuth: []
 
-  /user/{userId}/cart/{productId}:
+  /user/{userId}/wishlist/{productId}:
     delete:
       tags:
       - user
@@ -913,7 +913,6 @@ paths:
                     type: string
                     enum:
                     - "Requested quantity is higher than available stock."
-                    - "Specified item is already in cart."
                     - "Requested quantity is higher than available stock."
                     - "Minimum quantity is 1."
 

--- a/server/api/user.js
+++ b/server/api/user.js
@@ -206,7 +206,7 @@ router.post('/:userId/cart', authentication.check, authorization.check, addToCar
         req.body.supplier, 
         req.body.warehouse, 
         req.body.transporter, 
-        req.body.quantity,
+        Number(req.body.quantity),
     ).then((result) => {        
         switch (result) {
             case null:
@@ -215,8 +215,6 @@ router.post('/:userId/cart', authentication.check, authorization.check, addToCar
                 return res.status(400).send({message: "Requested quantity is higher than available stock."})
             case "INVALID_COMBINATION":
                 return res.status(400).send({message: "Invalid combination of product, supplier and transporter."})
-            case "ALREADY_PRESENT":
-                return res.status(409).send({message: "Specified item is already in cart."})
             default:
                 return res.status(200).send({message: "Item successfully added to cart."})
         }


### PR DESCRIPTION
Utilizadores podem agora repetir um pedido post para incremendar a quantidade presente no carrinho, em vez de não ser permitido adicionar o mesmo produto mais do que uma vez.